### PR TITLE
📊 Redirect spdlog logs to Catch2 logging

### DIFF
--- a/test/TestLogging.h
+++ b/test/TestLogging.h
@@ -1,0 +1,52 @@
+/**
+ * @file TestLogging.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-11-11
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#pragma once
+
+#include <catch2/catch.hpp>
+#include <spdlog/sinks/base_sink.h>
+
+#include <string>
+
+template<typename Mutex>
+class TestSink : public spdlog::sinks::base_sink<Mutex>
+{
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        // Format the message:
+        spdlog::memory_buf_t formatted;
+        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+        std::string formattedMsg = fmt::to_string(formatted);
+        switch (msg.level)
+        {
+        case spdlog::level::trace:
+        case spdlog::level::debug:
+        case spdlog::level::info:
+        {
+            UNSCOPED_INFO(formattedMsg);
+            break;
+        }
+        case spdlog::level::warn:
+        {
+            WARN(formattedMsg);
+            break;
+        }
+        case spdlog::level::err:
+        case spdlog::level::critical:
+        {
+            FAIL_CHECK(formattedMsg);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    void flush_() override
+    { }
+};

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,5 +5,23 @@
  * @copyright Copyright (c) 2020 Hayden McAfee
  */
 
-#define CATCH_CONFIG_MAIN // This tells Catch to provide our main entrypoint
+#define CATCH_CONFIG_RUNNER // This tells Catch that we'll be providing the main entrypoint
 #include <catch2/catch.hpp>
+#include <spdlog/spdlog.h>
+
+#include "TestLogging.h"
+
+#include <memory>
+#include <mutex>
+
+int main(int argc, char* argv[])
+{
+    // Set up logging
+    auto testLoggingSink = std::make_shared<TestSink<std::mutex>>();
+    auto testLogger = std::make_shared<spdlog::logger>("testlogger", testLoggingSink);
+    spdlog::set_default_logger(testLogger);
+
+    // Test!
+    int result = Catch::Session().run(argc, argv);
+    return result;
+}


### PR DESCRIPTION
This change redirects spdlog logging to the test framework, so logs are properly captured as part of test cases (and indicate test failure, if appropriate).