### PR TITLE
🤔 Protocol spec changes to streamline relay connections

### DIFF
--- a/docs/uml/routing-strategy-activity.plantuml
+++ b/docs/uml/routing-strategy-activity.plantuml
@@ -1,0 +1,49 @@
+@startuml
+title Orchestration Routing Strategy Activity Diagram
+
+partition "Viewer Browser" {
+    start
+    :Viewer requests Channel 123 from Edge node;
+}
+
+partition "Edge Janus Instance" {
+    if (Edge has existing\nChannel 123 Stream?) then (yes)
+        :Send stream data to viewer;
+        stop
+    else (no)
+        :Subscribe to Channel 123;
+    endif
+}
+
+partition "Orchestrator" {
+    if (Channel 123 Stream exists\non Relay in same region?) then (yes)
+        if (Is Relay at capacity?) then(yes)
+        else (no)
+            :Orchestrator directs Relay to send\nChannel 123 stream to Edge;
+            stop
+        endif
+    else (no)
+    endif
+    if (Is a Relay in the same region available?) then (yes)
+        :Orchestrator directs Ingest to send\nChannel 123 stream to regional Relay;
+        :Orchestrator directs regional Relay\nto send Channel 123 to Edge;
+        :Edge sends stream data to viewer;
+        stop
+    else (no)
+    endif
+    if (Is a Relay in a different region available?) then (yes)
+        :Orchestrator directs Ingest to send\nChannel 123 stream to non-regional Relay;
+        :Orchestrator directs non-regional Relay\nto send Channel 123 to Edge;
+        :Edge sends stream data to viewer;
+        stop
+    else (no)
+    endif
+    if (Is Ingest at capacity?) then (yes)
+        :Error - we ran out of capacity;
+        end
+    else (no)
+        :Orchestrator directs Ingest to\nsend Channel 123 stream to Edge;
+        stop
+    endif
+}
+@enduml

--- a/docs/uml/sequence-diagram-no-relays.plantuml
+++ b/docs/uml/sequence-diagram-no-relays.plantuml
@@ -27,8 +27,8 @@ nyStreamer -> nyc: New stream starts for channel 1
 note left
     Streamer begins streaming
 end note
-nyc --> orchestrator: Stream Available Request
-nyc <-- orchestrator: Stream Available Response
+nyc --> orchestrator: Stream Publish Request
+nyc <-- orchestrator: Stream Publish Response
 
 == Viewer Starts Viewing ==
 seaViewer -> sea: Request to watch channel 1
@@ -41,7 +41,7 @@ note right
     generated and sent with this request
 end note
 sea <-- orchestrator: Subscribe Channel Response
-nyc <-- orchestrator: Stream Start Relay
+nyc <-- orchestrator: Stream Relaying Request
 sea <-- nyc: Channel 1 stream relayed via FTL
 note left
     The stream key for FTL relay is sent
@@ -54,8 +54,8 @@ nyStreamer -> nyc: Stream stops for channel 1
 note left
     Streamer stops streaming
 end note
-nyc --> orchestrator: Stream removed request
-nyc <-- orchestrator: Stream removed response
+nyc --> orchestrator: Stream Unpublish request
+nyc <-- orchestrator: Stream Unpublish response
 nyc --X sea: Channel 1 stream relay is ended
 sea --> seaViewer: Channel 1 stream ended
 @enduml

--- a/docs/uml/sequence-diagram-with-relays.plantuml
+++ b/docs/uml/sequence-diagram-with-relays.plantuml
@@ -1,0 +1,86 @@
+@startuml
+autonumber
+title FTL Orchestration Service Flow with Relay Layer
+
+actor nyStreamer as "NYC Streamer"
+participant ingest as "Janus NYC Ingest"
+participant orchestrator as "FTL Orchestration Service"
+participant relay as "Janus West Relay"
+participant edge as "Janus SEA Edge"
+actor edgeViewer as "SEA Viewer"
+
+== FTL Instance Registration ==
+' Ingest intro sequence
+ingest --> orchestrator: Intro Request
+note left
+    Ingest server registers
+    with the Orchestration Service
+end note
+ingest <-- orchestrator: Intro Response
+
+' Relay intro sequence
+orchestrator <-- relay: Intro Request
+note right
+    Relay server registers
+    with the Orchestration service
+end note
+orchestrator --> relay: Intro Response
+
+' Edge intro sequence
+orchestrator <-- edge: Intro Request
+note right
+    Edge server registers
+    with the Orchestration Service
+end note
+orchestrator --> edge: Intro Response
+
+== Streamer Starts Streaming ==
+nyStreamer -> ingest: New stream starts for channel 1
+note left
+    Streamer begins streaming
+end note
+ingest --> orchestrator: Stream Publish Request
+ingest <-- orchestrator: Stream Publish Response
+
+== Viewer Starts Viewing ==
+' Edge watch request
+edge <- edgeViewer : Request to watch channel 1
+note right
+    Viewer starts watching
+end note
+orchestrator <-- edge : Subscribe Channel Request
+note right
+    A new stream key for this channel is
+    generated and sent with this request
+end note
+orchestrator --> edge : Subscribe Channel Response
+
+' Relay relay request
+orchestrator --> relay: Stream Relaying Request
+note left
+    Orchestrator tells the Relay node to relay
+    the Channel 1 stream to the SEA Edge
+end note
+orchestrator <-- relay: Stream Relaying Response
+
+ingest <-- orchestrator: Stream Relaying Request
+note right
+    Orchestrator tells the Ingest node to relay
+    the Channel 1 stream to the West Relay
+end note
+ingest --> orchestrator: Stream Relaying Response
+ingest --> relay: Channel 1 stream relayed via FTL
+relay --> edge: Channel 1 stream relayed via FTL
+edge --> edgeViewer: Channel 1 stream is delivered via WebRTC
+
+== Streamer Stops Streaming ==
+nyStreamer -> ingest: Stream stops for channel 1
+note left
+    Streamer stops streaming
+end note
+ingest --> orchestrator: Stream Unpublish request
+ingest <-- orchestrator: Stream Unpublish response
+ingest --X relay: Channel 1 stream has ended
+relay --X edge: Channel 1 stream has ended
+edge --X edgeViewer: Channel 1 stream ended
+@enduml

--- a/docs/uml/stream-routing-use-case.plantuml
+++ b/docs/uml/stream-routing-use-case.plantuml
@@ -1,0 +1,89 @@
+@startuml
+title FTL Stream Routing Overview
+left to right direction
+
+' Streamers
+package "NYC Streamers" {
+    :NYC Streamer 1: as nycs1
+    :NYC Streamer 2: as nycs2
+}
+
+package "SEA Streamers" {
+    :SEA Streamer 1: as seas1
+    :SEA Streamer 2: as seas2
+}
+
+' Ingests
+package "NYC Ingest Servers" {
+    (NYC Ingest 1) as nyci1
+    (NYC Ingest 2) as nyci2
+}
+
+package "SEA Ingest Servers" {
+    (SEA Ingest 1) as seai1
+    (SEA Ingest 2) as seai2
+}
+
+' Relays
+package "NYC Relay Servers" as nycRelays {
+    (NYC Relay 1) as nycr1
+    (NYC Relay 2) as nycr2
+}
+
+package "SEA Relay Servers" {
+    (SEA Relay 1) as sear1
+    (SEA Relay 2) as sear2
+}
+
+' Edges
+package "NYC Edge Servers" {
+    (NYC Edge 1) as nyce1
+    (NYC Edge 2) as nyce2
+}
+
+package "SEA Edge Servers" {
+    (SEA Edge 1) as seae1
+    (SEA Edge 2) as seae2
+}
+
+' Viewers
+package "NYC Viewers" {
+    :NYC Viewer 1: as nycv1
+    :NYC Viewer 2: as nycv2
+}
+
+package "SEA Viewers" {
+    :SEA Viewer 1: as seav1
+    :SEA Viewer 2: as seav2
+}
+
+' Streamers connect to their region's ingests
+nycs1 --> nyci1
+nycs2 --> nyci2
+seas1 --> seai1
+seas2 --> seai2
+note left of nycs1: Each streamer is distributed\nto a regional ingest
+
+' Viewers connect to their regional edge node
+nyce1 --> nycv1
+note right of nycv1: This viewer wants to\nwatch NYC Streamer 1
+nyce2 --> nycv2
+note right of nycv2: This viewer wants to\nwatch SEA Streamer 2
+seae1 --> seav1
+note right of seav1: This viewer wants to\nwatch SEA Streamer 1
+seae2 --> seav2
+note right of seav2: This viewer wants to\nwatch NYC Streamer 2
+
+' Regional edge nodes connect to regional relays
+nycr1 --> nyce1
+nycr2 --> nyce2
+sear1 --> seae1
+sear2 --> seae2
+
+' Regional edge nodes relay from original ingest
+nyci1 --> nycr1
+seai2 --> nycr2
+seai1 --> sear1
+nyci2 --> sear2
+
+@enduml

--- a/docs/uml/typical-flow.plantuml
+++ b/docs/uml/typical-flow.plantuml
@@ -36,10 +36,17 @@ note right
     Viewer starts watching
 end note
 sea --> orchestrator: Subscribe Channel Request
+note right
+    A new stream key for this channel is
+    generated and sent with this request
+end note
 sea <-- orchestrator: Subscribe Channel Response
-sea <-- orchestrator: Stream Available Request
-sea --> nyc: Request stream relay for channel 1
-sea <-- nyc: Channel 1 stream is relayed
+nyc <-- orchestrator: Stream Start Relay
+sea <-- nyc: Channel 1 stream relayed via FTL
+note left
+    The stream key for FTL relay is sent
+    with the Start Relay message
+end note
 sea --> seaViewer: Channel 1 stream is delivered via WebRTC
 
 == Streamer Stops Streaming ==
@@ -49,7 +56,6 @@ note left
 end note
 nyc --> orchestrator: Stream removed request
 nyc <-- orchestrator: Stream removed response
-orchestrator --> sea: Stream removed request
-orchestrator <-- sea: Stream removed response
+nyc --X sea: Channel 1 stream relay is ended
 sea --> seaViewer: Channel 1 stream ended
 @enduml


### PR DESCRIPTION
Updating the spec with a slightly different flow, allowing ingest nodes to relay streams to edge and relay nodes as if they were plain old FTL connections. A generated stream key is now included with channel subscriptions, and that stream key is used by ingest nodes to open FTL relay connections to any subscribed edge nodes.

This should simplify the relay process by relying on existing FTL protocol mechanisms for relaying video data between nodes.

This change also updates messages to allow nodes to identify themselves as relay nodes used only to forward stream video data between other nodes. Nodes can also provide a region string, used to help Orchestrator prioritize routes in the same region. Nodes can also indicate their current load, so Orchestrator can avoid routing bottlenecks.

For the diagrams in `PROTOCOL.md`, see below - the in-line images won't work until this is merged to main.

# Diagrams

_Video Routing Diagram `uml/stream-routing-use-case.plantuml`: This diagram visualizes the high-level flow of video traffic from streamers through relay servers to edge nodes that viewers connect to._

![Video Routing Diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/Glimesh/janus-ftl-orchestrator/protocol-revision/docs/uml/stream-routing-use-case.plantuml)


_Routing Strategy Activity Diagram `uml/routing-strategy-activity.plantuml`: This diagram visualizes the routing strategy that the Orchestrator will use to route streams from ingest nodes to edge nodes._

![Routing Strategy Activity Diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/Glimesh/janus-ftl-orchestrator/protocol-revision/docs/uml/routing-strategy-activity.plantuml)


_FTL Orchestration Sequence Diagram, No Relays `uml/sequence-diagram-no-relays.plantuml`: This diagram shows the expected sequence of calls to route a stream in a service graph without any relay nodes._

![FTL Orchestration Sequence Diagram, No Relays](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/Glimesh/janus-ftl-orchestrator/protocol-revision/docs/uml/sequence-diagram-no-relays.plantuml)


_FTL Orchestration Sequence Diagram, Relays `uml/sequence-diagram-with-relays.plantuml`: This diagram shows the expected sequence of calls to route a stream in a service graph with relay nodes between ingests and edges._

![FTL Orchestration Sequence Diagram, Relays](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/Glimesh/janus-ftl-orchestrator/protocol-revision/docs/uml/sequence-diagram-with-relays.plantuml)