### PR TITLE
🌯 Use meson wrap for catch2 dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
 build/
 builddir/
-subprojects/
+subprojects/*
 !subprojects/*.wrap

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 build/
 builddir/
+subprojects/
+!subprojects/*.wrap

--- a/README.md
+++ b/README.md
@@ -17,17 +17,6 @@ These are available in Ubuntu's package repos:
 - `libspdlog-dev`
 - `openssl`
 
-### Installing Catch2
-
-Catch2, sadly, is not available in Ubuntu's default repositories.
-
-```sh
-git clone https://github.com/catchorg/Catch2.git
-cd Catch2
-cmake -Bbuild -H. -DBUILD_TESTING=OFF
-sudo cmake --build build/ --target install
-```
-
 # Building
 
 ```sh

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ deps = [
     dependency('libssl'),
     dependency('libcrypto'),
     dependency('spdlog'),
+    dependency('catch2', fallback: ['catch2', 'catch2_dep']),
 ]
 
 cppargs = ['-std=c++20', '-Wno-unknown-pragmas']

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = Catch2-2.13.3
+source_url = https://github.com/catchorg/Catch2/archive/v2.13.3.zip
+source_filename = Catch2-2.13.3.zip
+source_hash = 1804feb72bc15c0856b4a43aa586c661af9c3685a75973b6a8fc0b950c7cfd13
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/catch2/2.13.3/1/get_zip
+patch_filename = catch2-2.13.3-1-wrap.zip
+patch_hash = eec2db9d30d6d722a78160e24ae3382623cc4dda1f9536407548af0b60db56c0
+
+[provide]
+dependency_names = catch2_dep
+


### PR DESCRIPTION
Discovered [meson wrap](https://mesonbuild.com/Wrap-dependency-system-manual.html) while messing around with getting catch2 installed correctly.

This is hopefully an easier approach to dependency management than readme instructions, basically if you have catch2 already on the include path it will be used, otherwise at build time meson will pull down the wrap version. New deps can be "installed" using the `meson wrap` commands.