### PR TITLE
♻️ Refactor subscription getters

### DIFF
--- a/src/Orchestrator.cpp
+++ b/src/Orchestrator.cpp
@@ -47,7 +47,7 @@ std::set<ftl_channel_id_t> Orchestrator<TConnection>::GetSubscribedChannels(
     std::set<ftl_channel_id_t> returnVal;
     for (const auto& sub : subscriptions.GetSubscriptions(connection))
     {
-        returnVal.insert(sub.ChannelId);
+        returnVal.insert(sub->ChannelId);
     }
     return returnVal;
 }
@@ -153,7 +153,7 @@ void Orchestrator<TConnection>::connectionClosed(std::weak_ptr<TConnection> conn
         // First, clear any active routes to this connection
         for (const auto& sub : subscriptions.GetSubscriptions(strongConnection))
         {
-            if (auto stream = streamStore.GetStreamByChannelId(sub.ChannelId))
+            if (auto stream = streamStore.GetStreamByChannelId(sub->ChannelId))
             {
                 closeRoute(stream.value(), strongConnection);
             }
@@ -329,11 +329,9 @@ ConnectionResult Orchestrator<TConnection>::connectionStreamPublish(
             streamStore.AddStream(newStream);
 
             // Start opening relays to any subscribed connections
-            std::vector<ChannelSubscription<TConnection>> channelSubs = 
-                subscriptions.GetSubscriptions(payload.ChannelId);
-            for (const auto& subscription : channelSubs)
+            for (const auto& subscription : subscriptions.GetSubscriptions(payload.ChannelId))
             {
-                openRoute(newStream, subscription.SubscribedConnection, subscription.StreamKey);
+                openRoute(newStream, subscription->SubscribedConnection, subscription->StreamKey);
             }
 
             return ConnectionResult

--- a/src/StreamStore.h
+++ b/src/StreamStore.h
@@ -96,9 +96,10 @@ public:
     std::optional<Stream<TConnection>> GetStreamByChannelId(ftl_channel_id_t channelId)
     {
         std::lock_guard<std::mutex> lock(streamStoreMutex);
-        if (streamByChannelId.count(channelId) > 0)
+        auto it = streamByChannelId.find(channelId);
+        if (it != streamByChannelId.end())
         {
-            return streamByChannelId[channelId];
+            return it->second;
         }
         return std::nullopt;
     }

--- a/src/SubscriptionStore.h
+++ b/src/SubscriptionStore.h
@@ -72,7 +72,7 @@ public:
      * @param channelId channel ID to remove subscription for
      * @return bool true if the subscription was successfully found and removed
      */
-    bool RemoveSubscription(std::shared_ptr<TConnection> connection, ftl_channel_id_t channelId)
+    bool RemoveSubscription(const std::shared_ptr<TConnection>& connection, const ftl_channel_id_t& channelId)
     {
         std::lock_guard<std::mutex> lock(subscriptionsStoreMutex);
         bool success = true;
@@ -154,39 +154,33 @@ public:
     /**
      * @brief Get the list of channel subscriptions that exist for a connection
      * @param connection connection to fetch subscribed channels for
-     * @return std::set<ftl_channel_id_t> set of channels this connection is subscribed to
+     * @return set of channels this connection is subscribed to
      */
-    std::vector<ChannelSubscription<TConnection>> GetSubscriptions(std::shared_ptr<TConnection> connection)
+    std::set<std::shared_ptr<ChannelSubscription<TConnection>>> GetSubscriptions(const std::shared_ptr<TConnection>& connection)
     {
-        std::vector<ChannelSubscription<TConnection>> returnVal;
         std::lock_guard<std::mutex> lock(subscriptionsStoreMutex);
-        if (subscriptionsByConnection.contains(connection))
+        auto it = subscriptionsByConnection.find(connection);
+        if (it != subscriptionsByConnection.end())
         {
-            for (const auto& subscription : subscriptionsByConnection[connection])
-            {
-                returnVal.push_back(*subscription);
-            }
+            return it->second;
         }
-        return returnVal;
+        return {};
     }
 
     /**
      * @brief Get the list of subscriptions to a given channel
      * @param channelId channel to fetch subscriptions for
-     * @return std::vector<ChannelSubscription> list of subscriptions for the given channel
+     * @return subscriptions for the given channelId
      */
-    std::vector<ChannelSubscription<TConnection>> GetSubscriptions(ftl_channel_id_t channelId)
+    std::set<std::shared_ptr<ChannelSubscription<TConnection>>> GetSubscriptions(const ftl_channel_id_t& channelId)
     {
-        std::vector<ChannelSubscription<TConnection>> returnVal;
         std::lock_guard<std::mutex> lock(subscriptionsStoreMutex);
-        if (subscriptionsByChannel.contains(channelId))
+        auto it = subscriptionsByChannel.find(channelId);
+        if (it != subscriptionsByChannel.end())
         {
-            for (const auto& subscription : subscriptionsByChannel[channelId])
-            {
-                returnVal.push_back(*subscription);
-            }
+            return it->second;
         }
-        return returnVal;
+        return {};
     }
 
     /**


### PR DESCRIPTION
No functional impact. I tend to learn by refactoring so no worries if this change isn't wanted.

Tried to follow what I understand is convention to map's find() for lookups, though it still seems awkward to compare with `end()`, https://stackoverflow.com/a/33239463

Simplified getter by returning a copy of the subscriber set directly instead of building a new vector by hand (experimented with other methods but a copy is needed afaict because the lock is only for this method, after it returns the set could end up changing).

Also taking in key parameters as const reference for clarity and skipping an unneeded copy. Kept them as shared_ptr for now because the map keys themselves are shared_ptrs.