### PR TITLE
🌯 Use meson wrapped spdlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Please see [PROTOCOL.md](/docs/PROTOCOL.md)
 
 These are available in Ubuntu's package repos:
 
-- `libspdlog-dev`
 - `openssl`
 
 # Building

--- a/meson.build
+++ b/meson.build
@@ -10,8 +10,8 @@ sources = files([
 deps = [
     dependency('libssl'),
     dependency('libcrypto'),
-    dependency('spdlog'),
     dependency('catch2', fallback: ['catch2', 'catch2_dep']),
+    subproject('spdlog').get_variable('spdlog_dep'), # use wrapped copy of spdlog
 ]
 
 cppargs = ['-std=c++20', '-Wno-unknown-pragmas']

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = spdlog-1.8.1
+source_url = https://github.com/gabime/spdlog/archive/v1.8.1.tar.gz
+source_filename = v1.8.1.tar.gz
+source_hash = 5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/spdlog/1.8.1/1/get_zip
+patch_filename = spdlog-1.8.1-1-wrap.zip
+patch_hash = 76844292a8e912aec78450618271a311841b33b17000988f215ddd6c64dd71b3
+
+[provide]
+dependency_names = spdlog


### PR DESCRIPTION
To avoid annoying versioning problems, switch to using the Meson wrapped version of Spdlog instead of whatever locally installed version exists on the build machine,