### PR TITLE
⚡ First end-to-end ingest <-> edge relay test

### DIFF
--- a/inc/FtlConnection.h
+++ b/inc/FtlConnection.h
@@ -50,30 +50,34 @@ public:
      * @param bytes bytes to parse
      * @return OrchestrationMessageHeader resulting header information
      */
-    static OrchestrationMessageHeader ParseMessageHeader(const std::vector<uint8_t>& bytes)
+    static OrchestrationMessageHeader ParseMessageHeader(const std::vector<std::byte>& bytes)
     {
         if (bytes.size() < 4)
         {
             throw std::range_error("Attempt to parse message header that is under 4 bytes.");
         }
 
-        uint8_t messageDesc = bytes.at(0);
-        OrchestrationMessageDirectionKind messageDirection = (messageDesc & 0b10000000) == 0 ?
-            OrchestrationMessageDirectionKind::Request : OrchestrationMessageDirectionKind::Response;
-        bool messageIsFailure = ((messageDesc & 0b01000000) != 0);
+        std::byte messageDesc = bytes.at(0);
+        OrchestrationMessageDirectionKind messageDirection = 
+            ((messageDesc & std::byte{0b10000000}) == std::byte{0}) ?
+                OrchestrationMessageDirectionKind::Request : 
+                OrchestrationMessageDirectionKind::Response;
+        bool messageIsFailure = ((messageDesc & std::byte{0b01000000}) != std::byte{0});
         OrchestrationMessageType messageType = 
-            static_cast<OrchestrationMessageType>(messageDesc & 0b00111111);
-        uint8_t messageId = bytes.at(1);
+            static_cast<OrchestrationMessageType>(messageDesc & std::byte{0b00111111});
+        uint8_t messageId = static_cast<uint8_t>(bytes.at(1));
         // Determine if we need to flip things around if the host byte ordering is not the same
         // as network byte ordering (big endian)
         uint16_t payloadLength;
         if (std::endian::native != std::endian::big)
         {
-            payloadLength = (static_cast<uint16_t>(bytes.at(3)) << 8) | bytes.at(2);
+            payloadLength = (static_cast<uint16_t>(bytes.at(3)) << 8) | 
+                static_cast<uint16_t>(bytes.at(2));
         }
         else
         {
-            payloadLength = (static_cast<uint16_t>(bytes.at(2)) << 8) | bytes.at(3);
+            payloadLength = (static_cast<uint16_t>(bytes.at(2)) << 8) | 
+                static_cast<uint16_t>(bytes.at(3));
         }
 
         return OrchestrationMessageHeader
@@ -89,28 +93,28 @@ public:
     /**
      * @brief Serializes an Orchestration Protocol Message Header to a byte array
      * @param header header to serialize
-     * @return std::vector<uint8_t> serialized bytes
+     * @return std::vector<std::byte> serialized bytes
      */
-    static std::vector<uint8_t> SerializeMessageHeader(const OrchestrationMessageHeader& header)
+    static std::vector<std::byte> SerializeMessageHeader(const OrchestrationMessageHeader& header)
     {
-        std::vector<uint8_t> headerBytes;
+        std::vector<std::byte> headerBytes;
         headerBytes.reserve(4);
 
         // Convert header to byte payload
-        uint8_t messageDesc = static_cast<uint8_t>(header.MessageType);
+        std::byte messageDesc = static_cast<std::byte>(header.MessageType);
         if (header.MessageDirection == OrchestrationMessageDirectionKind::Response)
         {
-            messageDesc = (messageDesc | 0b10000000);
+            messageDesc = (messageDesc | std::byte{0b10000000});
         }
         if (header.MessageFailure)
         {
-            messageDesc = (messageDesc | 0b01000000);
+            messageDesc = (messageDesc | std::byte{0b01000000});
         }
         headerBytes.emplace_back(messageDesc);
-        headerBytes.emplace_back(header.MessageId);
+        headerBytes.emplace_back(static_cast<std::byte>(header.MessageId));
 
         // Encode payload length
-        std::vector<uint8_t> payloadLengthBytes = ConvertToNetworkPayload(header.MessagePayloadLength);
+        std::vector<std::byte> payloadLengthBytes = ConvertToNetworkPayload(header.MessagePayloadLength);
         headerBytes.insert(headerBytes.end(), payloadLengthBytes.begin(), payloadLengthBytes.end());
 
         return headerBytes;
@@ -122,22 +126,22 @@ public:
      *  (swapping byte order if necessary)
      * 
      * @param value The value to convert
-     * @return std::vector<uint8_t> The resulting payload
+     * @return std::vector<std::byte> The resulting payload
      */
-    static std::vector<uint8_t> ConvertToNetworkPayload(const uint16_t value)
+    static std::vector<std::byte> ConvertToNetworkPayload(const uint16_t value)
     {
-        std::vector<uint8_t> payload;
+        std::vector<std::byte> payload;
         payload.reserve(2); // 16 bits
 
         if (std::endian::native != std::endian::big)
         {
-            payload.emplace_back(static_cast<uint8_t>(value & 0x00FF));
-            payload.emplace_back(static_cast<uint8_t>((value >> 8) & 0x00FF));
+            payload.emplace_back(static_cast<std::byte>(value & 0x00FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 8) & 0x00FF));
         }
         else
         {
-            payload.emplace_back(static_cast<uint8_t>((value >> 8) & 0x00FF));
-            payload.emplace_back(static_cast<uint8_t>(value & 0x00FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 8) & 0x00FF));
+            payload.emplace_back(static_cast<std::byte>(value & 0x00FF));
         }
 
         return payload;
@@ -149,26 +153,26 @@ public:
      *  (swapping byte order if necessary)
      * 
      * @param value The value to convert
-     * @return std::vector<uint8_t> The resulting payload
+     * @return std::vector<std::byte> The resulting payload
      */
-    static std::vector<uint8_t> ConvertToNetworkPayload(const uint32_t value)
+    static std::vector<std::byte> ConvertToNetworkPayload(const uint32_t value)
     {
-        std::vector<uint8_t> payload;
+        std::vector<std::byte> payload;
         payload.reserve(4); // 32 bits
 
         if (std::endian::native != std::endian::big)
         {
-            payload.emplace_back(static_cast<uint8_t>(value & 0x000000FF));
-            payload.emplace_back(static_cast<uint8_t>((value >> 8) & 0x000000FF));
-            payload.emplace_back(static_cast<uint8_t>((value >> 16) & 0x000000FF));
-            payload.emplace_back(static_cast<uint8_t>((value >> 24) & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>(value & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 8) & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 16) & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 24) & 0x000000FF));
         }
         else
         {
-            payload.emplace_back(static_cast<uint8_t>((value >> 24) & 0x000000FF));
-            payload.emplace_back(static_cast<uint8_t>((value >> 16) & 0x000000FF));
-            payload.emplace_back(static_cast<uint8_t>((value >> 8) & 0x000000FF));
-            payload.emplace_back(static_cast<uint8_t>(value & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 24) & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 16) & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>((value >> 8) & 0x000000FF));
+            payload.emplace_back(static_cast<std::byte>(value & 0x000000FF));
         }
 
         return payload;
@@ -180,8 +184,8 @@ public:
      * @return uint16_t Resulting value
      */
     static uint16_t DeserializeNetworkUint16(
-        const std::vector<uint8_t>::const_iterator& begin,
-        const std::vector<uint8_t>::const_iterator& end)
+        const std::vector<std::byte>::const_iterator& begin,
+        const std::vector<std::byte>::const_iterator& end)
     {
         if ((end - begin) != 2)
         {
@@ -206,8 +210,8 @@ public:
      * @return uint32_t Resulting value
      */
     static uint32_t DeserializeNetworkUint32(
-        const std::vector<uint8_t>::const_iterator& begin,
-        const std::vector<uint8_t>::const_iterator& end)
+        const std::vector<std::byte>::const_iterator& begin,
+        const std::vector<std::byte>::const_iterator& end)
     {
         if ((end - begin) != 4)
         {
@@ -230,41 +234,49 @@ public:
         }
     }
 
+    /**
+     * @brief Given a payload of bytes, append a string to the end. Encapsulates annoying casting.
+     * @param payload Payload to append to
+     * @param string String to append
+     */
+    static void AppendStringToPayload(std::vector<std::byte>& payload, const std::string& string)
+    {
+        payload.insert(
+            payload.end(),
+            reinterpret_cast<const std::byte*>(string.data()),
+            (reinterpret_cast<const std::byte*>(string.data()) + string.size()));
+    }
+
     /* IConnection */
     void Start() override
     {
         // Bind to transport events
+        transport->SetOnBytesReceived(
+            std::bind(
+                &FtlConnection::onTransportBytesReceived,
+                this,
+                std::placeholders::_1));
         transport->SetOnConnectionClosed(std::bind(&FtlConnection::onTransportConnectionClosed, this));
 
         // Start the transport
         transport->Start();
-
-        // Spin up the thread that will listen to data coming from our transport
-        connectionThreadEndedFuture = connectionThreadEndedPromise.get_future();
-        connectionThread = std::thread(&FtlConnection::startConnectionThread, this);
-        connectionThread.detach();
     }
 
     void Stop() override
     {
-        if (!isStopping && !isTransportStopped)
-        {
-            isStopping = true;
-            // Stop the transport, which should halt our connection thread.
-            transport->Stop();
-            connectionThreadEndedFuture.get(); // Wait until our connection thread end has ended
-        }
+        // Stop the transport, which should halt our connection thread.
+        transport->Stop();
     }
 
     void SendIntro(const ConnectionIntroPayload& payload) override
     {
         // Construct the binary payload
-        std::vector<uint8_t> messagePayload
+        std::vector<std::byte> messagePayload
         {
-            payload.VersionMajor,
-            payload.VersionMinor,
-            payload.VersionRevision,
-            payload.RelayLayer,
+            static_cast<std::byte>(payload.VersionMajor),
+            static_cast<std::byte>(payload.VersionMinor),
+            static_cast<std::byte>(payload.VersionRevision),
+            static_cast<std::byte>(payload.RelayLayer),
         };
         auto regionCodeLength = FtlConnection::ConvertToNetworkPayload(
             static_cast<uint16_t>(payload.RegionCode.size()));
@@ -272,14 +284,8 @@ public:
             messagePayload.end(),
             regionCodeLength.begin(),
             regionCodeLength.end());
-        messagePayload.insert(
-            messagePayload.end(),
-            payload.RegionCode.begin(),
-            payload.RegionCode.end());
-        messagePayload.insert(
-            messagePayload.end(),
-            payload.Hostname.begin(),
-            payload.Hostname.end());
+        AppendStringToPayload(messagePayload, payload.RegionCode);
+        AppendStringToPayload(messagePayload, payload.Hostname);
 
         // Construct the message header
         OrchestrationMessageHeader header
@@ -297,9 +303,8 @@ public:
     
     void SendOutro(const ConnectionOutroPayload& payload) override
     {
-        std::vector<uint8_t> messagePayload(
-            payload.DisconnectReason.begin(),
-            payload.DisconnectReason.end());
+        std::vector<std::byte> messagePayload;
+        AppendStringToPayload(messagePayload, payload.DisconnectReason);
         
         OrchestrationMessageHeader header
         {
@@ -315,7 +320,7 @@ public:
 
     void SendNodeState(const ConnectionNodeStatePayload& payload) override
     {
-        std::vector<uint8_t> messagePayload;
+        std::vector<std::byte> messagePayload;
         messagePayload.reserve(8);
         auto currentLoad = ConvertToNetworkPayload(payload.CurrentLoad);
         messagePayload.insert(messagePayload.end(), currentLoad.begin(), currentLoad.end());
@@ -336,18 +341,18 @@ public:
 
     void SendChannelSubscription(const ConnectionSubscriptionPayload& payload) override
     {
-        std::vector<uint8_t> messagePayload
+        std::vector<std::byte> messagePayload
         {
-            static_cast<uint8_t>(payload.IsSubscribe),
+            static_cast<std::byte>(payload.IsSubscribe),
         };
 
         messagePayload.reserve(5 + payload.StreamKey.size());
         auto channelIdBytes = ConvertToNetworkPayload(payload.ChannelId);
         messagePayload.insert(messagePayload.end(), channelIdBytes.begin(), channelIdBytes.end());
-        for (const auto& streamKeyByte : payload.StreamKey)
-        {
-            messagePayload.push_back(static_cast<uint8_t>(streamKeyByte));
-        }
+        messagePayload.insert(
+            messagePayload.end(),
+            payload.StreamKey.begin(),
+            payload.StreamKey.end());
 
         OrchestrationMessageHeader header
         {
@@ -363,9 +368,9 @@ public:
     
     void SendStreamPublish(const ConnectionPublishPayload& payload) override
     {
-        std::vector<uint8_t> messagePayload
+        std::vector<std::byte> messagePayload
         {
-            static_cast<uint8_t>(payload.IsPublish),
+            static_cast<std::byte>(payload.IsPublish),
         };
         messagePayload.reserve(9);
         auto channelIdBytes = ConvertToNetworkPayload(payload.ChannelId);
@@ -387,7 +392,7 @@ public:
 
     void SendStreamRelay(const ConnectionRelayPayload& payload) override
     {
-        std::vector<uint8_t> messagePayload
+        std::vector<std::byte> messagePayload
         {
             static_cast<uint8_t>(payload.IsStartRelay),
         };
@@ -402,14 +407,11 @@ public:
             messagePayload.end(),
             hostnameSizeBytes.begin(),
             hostnameSizeBytes.end());
+        AppendStringToPayload(messagePayload, payload.TargetHostname);
         messagePayload.insert(
             messagePayload.end(),
-            payload.TargetHostname.begin(),
-            payload.TargetHostname.end());
-        for (const auto& streamKeyByte : payload.StreamKey)
-        {
-            messagePayload.push_back(static_cast<uint8_t>(streamKeyByte));
-        }
+            payload.StreamKey.begin(),
+            payload.StreamKey.end());
 
         OrchestrationMessageHeader header
         {
@@ -465,11 +467,8 @@ public:
 
 private:
     std::shared_ptr<IConnectionTransport> transport;
-    std::atomic<bool> isStopping { false };
-    std::atomic<bool> isTransportStopped { false };
-    std::promise<void> connectionThreadEndedPromise;
-    std::future<void> connectionThreadEndedFuture;
-    std::thread connectionThread;
+    std::vector<std::byte> transportReadBuffer;
+    std::optional<OrchestrationMessageHeader> parsedTransportMessageHeader;
     std::function<void(void)> onConnectionClosed;
     connection_cb_intro_t onIntro;
     connection_cb_outro_t onOutro;
@@ -482,62 +481,47 @@ private:
 
     /* Private methods */
     /**
-     * @brief
-     *  Method body intended to run on a different thread initialized by Start(), handles
-     *  incoming connection data.
+     * @brief Called when underlying transport has received new data
+     * @param bytes data from transport
      */
-    void startConnectionThread()
+    void onTransportBytesReceived(const std::vector<std::byte>& bytes)
     {
-        std::optional<OrchestrationMessageHeader> messageHeader;
-        std::vector<uint8_t> buffer;
-        while (true)
+        // Add received bytes to our buffer
+        spdlog::info("{} received {} bytes ...", GetHostname(), bytes.size());
+        transportReadBuffer.insert(transportReadBuffer.end(), bytes.begin(), bytes.end());
+
+        // Parse the header if we haven't already
+        if (!parsedTransportMessageHeader.has_value())
         {
-            if (isTransportStopped)
+            // Do we have enough bytes for a header?
+            if (transportReadBuffer.size() >= 4)
             {
-                break;
+                OrchestrationMessageHeader parsedHeader = ParseMessageHeader(transportReadBuffer);
+                parsedTransportMessageHeader.emplace(parsedHeader);
             }
-
-            // Try to read in some data
-            spdlog::info("Attempting to read for {} ...", GetHostname());
-            std::vector<uint8_t> readBytes = transport->Read();
-            buffer.insert(buffer.end(), readBytes.begin(), readBytes.end());
-
-            // Parse the header if we haven't already
-            if (!messageHeader.has_value())
+            else
             {
-                // Do we have enough bytes for a header?
-                if (buffer.size() >= 4)
-                {
-                    OrchestrationMessageHeader parsedHeader = ParseMessageHeader(buffer);
-                    messageHeader.emplace(parsedHeader);
-                }
-                else
-                {
-                    // We need more bytes before we can deal with this message.
-                    continue;
-                }
-            }
-            
-            // Do we have all the payload bytes we need to process this message?
-            uint16_t messagePayloadLength = messageHeader.value().MessagePayloadLength;
-            if ((buffer.size() - 4) >= messagePayloadLength)
-            {
-                std::vector<uint8_t> messagePayload = std::vector<uint8_t>(
-                    (buffer.begin() + 4),
-                    (buffer.begin() + 4 + messagePayloadLength));
-
-                // Process the message, then remove the message from the read buffer
-                processMessage(messageHeader.value(), messagePayload);
-                buffer.erase(buffer.begin(), (buffer.begin() + 4 + messagePayloadLength));
-                messageHeader.reset();
+                // We need more bytes before we can deal with this message.
+                // Wait for our transport to deliver us more juicy data.
+                return;
             }
         }
-
-        if (onConnectionClosed)
+        
+        // Do we have all the payload bytes we need to process this message?
+        uint16_t messagePayloadLength = parsedTransportMessageHeader.value().MessagePayloadLength;
+        if ((transportReadBuffer.size() - 4) >= messagePayloadLength)
         {
-            onConnectionClosed();
+            std::vector<std::byte> messagePayload(
+                (transportReadBuffer.begin() + 4),
+                (transportReadBuffer.begin() + 4 + messagePayloadLength));
+
+            // Process the message, then remove the message from the read buffer
+            processMessage(parsedTransportMessageHeader.value(), messagePayload);
+            transportReadBuffer.erase(
+                transportReadBuffer.begin(),
+                (transportReadBuffer.begin() + 4 + messagePayloadLength));
+            parsedTransportMessageHeader.reset();
         }
-        connectionThreadEndedPromise.set_value_at_thread_exit();
     }
 
     /**
@@ -545,7 +529,10 @@ private:
      */
     void onTransportConnectionClosed()
     {
-        isTransportStopped = true;
+        if (onConnectionClosed)
+        {
+            onConnectionClosed();
+        }
     }
 
     /**
@@ -555,7 +542,7 @@ private:
      */
     void processMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         if (header.MessageDirection == OrchestrationMessageDirectionKind::Response)
         {
@@ -593,7 +580,7 @@ private:
      */
     void processIntroMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         if (payload.size() < 6)
         {
@@ -622,20 +609,23 @@ private:
                 .MessageId = header.MessageId,
                 .MessagePayloadLength = 0,
             };
-            sendMessage(responseHeader, std::vector<uint8_t>());
+            sendMessage(responseHeader, std::vector<std::byte>());
             return;
         }
 
         ConnectionIntroPayload introPayload
         {
-            .VersionMajor = payload.at(0),
-            .VersionMinor = payload.at(1),
-            .VersionRevision = payload.at(2),
-            .RelayLayer = payload.at(3),
+            .VersionMajor = static_cast<uint8_t>(payload.at(0)),
+            .VersionMinor = static_cast<uint8_t>(payload.at(1)),
+            .VersionRevision = static_cast<uint8_t>(payload.at(2)),
+            .RelayLayer = static_cast<uint8_t>(payload.at(3)),
             // (bytes 4, 5 are region code length)
-            .RegionCode = 
-                std::string((payload.cbegin() + 6), (payload.cbegin() + 6 + regionCodeLength)),
-            .Hostname = std::string((payload.cbegin() + 6 + regionCodeLength), payload.cend())
+            .RegionCode = std::string(
+                (reinterpret_cast<const char*>(payload.data()) + 6),
+                (reinterpret_cast<const char*>(payload.data()) + 6 + regionCodeLength)),
+            .Hostname = std::string(
+                (reinterpret_cast<const char*>(payload.data()) + 6 + regionCodeLength),
+                (reinterpret_cast<const char*>(payload.data()) + payload.size())),
         };
 
         // Indicate that we received an intro
@@ -657,7 +647,7 @@ private:
             .MessageId = header.MessageId,
             .MessagePayloadLength = 0,
         };
-        sendMessage(responseHeader, std::vector<uint8_t>());
+        sendMessage(responseHeader, std::vector<std::byte>());
     }
 
     /**
@@ -665,11 +655,13 @@ private:
      */
     void processOutroMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         ConnectionOutroPayload outroPayload
         {
-            .DisconnectReason = std::string(payload.begin(), payload.end())
+            .DisconnectReason = std::string(
+                reinterpret_cast<const char*>(payload.data()),
+                payload.size())
         };
 
         // Indicate that we received an intro
@@ -687,7 +679,7 @@ private:
             .MessageId = header.MessageId,
             .MessagePayloadLength = 0,
         };
-        sendMessage(responseHeader, std::vector<uint8_t>());
+        sendMessage(responseHeader, std::vector<std::byte>());
     }
 
     /**
@@ -695,7 +687,7 @@ private:
      */
     void processNodeStateMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         if (payload.size() < 8)
         {
@@ -712,7 +704,7 @@ private:
                 .MessageId = header.MessageId,
                 .MessagePayloadLength = 0,
             };
-            sendMessage(responseHeader, std::vector<uint8_t>());
+            sendMessage(responseHeader, std::vector<std::byte>());
             return;
         }
         
@@ -737,7 +729,7 @@ private:
             .MessageId = header.MessageId,
             .MessagePayloadLength = 0,
         };
-        sendMessage(responseHeader, std::vector<uint8_t>());
+        sendMessage(responseHeader, std::vector<std::byte>());
     }
 
     /**
@@ -745,7 +737,7 @@ private:
      */
     void processChannelSubscriptionMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         if (payload.size() < 5)
         {
@@ -753,15 +745,10 @@ private:
         }
 
         // TODO: We should be using std::byte everywhere...
-        std::vector<std::byte> streamKey;
-        streamKey.reserve(payload.size() - 5);
-        for (auto it = (payload.begin() + 5); it != payload.end(); ++it)
-        {
-            streamKey.push_back(static_cast<std::byte>(*it));
-        }
+        std::vector<std::byte> streamKey((payload.begin() + 5), payload.end());
         ConnectionSubscriptionPayload subPayload
         {
-            .IsSubscribe = (payload.at(0) == 1),
+            .IsSubscribe = (static_cast<uint8_t>(payload.at(0)) == 1),
             .ChannelId = DeserializeNetworkUint32((payload.cbegin() + 1), (payload.cbegin() + 5)),
             .StreamKey = streamKey,
         };
@@ -781,7 +768,7 @@ private:
             .MessageId = header.MessageId,
             .MessagePayloadLength = 0,
         };
-        sendMessage(responseHeader, std::vector<uint8_t>());
+        sendMessage(responseHeader, std::vector<std::byte>());
     }
 
     /**
@@ -789,7 +776,7 @@ private:
      */
     void processStreamPublishMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         if (payload.size() < 9)
         {
@@ -798,7 +785,7 @@ private:
 
         ConnectionPublishPayload publishPayload
         {
-            .IsPublish = (payload.at(0) == 1),
+            .IsPublish = (static_cast<uint8_t>(payload.at(0)) == 1),
             .ChannelId = DeserializeNetworkUint32((payload.cbegin() + 1), (payload.cbegin() + 5)),
             .StreamId = DeserializeNetworkUint32((payload.cbegin() + 5), (payload.cbegin() + 9)),
         };
@@ -818,7 +805,7 @@ private:
             .MessageId = header.MessageId,
             .MessagePayloadLength = 0,
         };
-        sendMessage(responseHeader, std::vector<uint8_t>());
+        sendMessage(responseHeader, std::vector<std::byte>());
     }
 
     /**
@@ -826,7 +813,7 @@ private:
      */
     void processStreamRelayMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
         if (payload.size() < 11)
         {
@@ -855,27 +842,20 @@ private:
                 .MessageId = header.MessageId,
                 .MessagePayloadLength = 0,
             };
-            sendMessage(responseHeader, std::vector<uint8_t>());
+            sendMessage(responseHeader, std::vector<std::byte>());
             return;
-        }
-
-        // TODO: Use std::byte everywhere to avoid these annoying casts...
-        std::vector<std::byte> streamKey;
-        streamKey.reserve(payload.size() - 11 - hostnameLength);
-        for (auto it = payload.cbegin() + 11 + hostnameLength; it < payload.cend(); ++it)
-        {
-            streamKey.push_back(static_cast<std::byte>(*it));
         }
 
         ConnectionRelayPayload relayPayload
         {
-            .IsStartRelay = (payload.at(0) == 1),
+            .IsStartRelay = (static_cast<uint8_t>(payload.at(0)) == 1),
             .ChannelId = DeserializeNetworkUint32((payload.cbegin() + 1), (payload.cbegin() + 5)),
             .StreamId = DeserializeNetworkUint32((payload.cbegin() + 5), (payload.cbegin() + 9)),
             // (bytes 10 - 11 are the hostname length)
-            .TargetHostname = 
-                std::string((payload.cbegin() + 11), (payload.cbegin() + 11 + hostnameLength)),
-            .StreamKey = streamKey,
+            .TargetHostname = std::string(
+                (reinterpret_cast<const char*>(payload.data()) + 11),
+                (reinterpret_cast<const char*>(payload.data()) + 11 + hostnameLength)),
+            .StreamKey = std::vector<std::byte>(payload.cbegin() + 11, payload.cend()),
         };
 
         // Indicate that we received a relay
@@ -893,7 +873,7 @@ private:
             .MessageId = header.MessageId,
             .MessagePayloadLength = 0,
         };
-        sendMessage(responseHeader, std::vector<uint8_t>());
+        sendMessage(responseHeader, std::vector<std::byte>());
     }
 
     /**
@@ -903,9 +883,9 @@ private:
      */
     void sendMessage(
         const OrchestrationMessageHeader& header,
-        const std::vector<uint8_t>& payload)
+        const std::vector<std::byte>& payload)
     {
-        std::vector<uint8_t> sendBuffer = SerializeMessageHeader(header);
+        std::vector<std::byte> sendBuffer = SerializeMessageHeader(header);
         sendBuffer.reserve(4 + payload.size());
 
         // Append payload

--- a/inc/FtlConnection.h
+++ b/inc/FtlConnection.h
@@ -38,12 +38,6 @@ public:
         hostname(hostname)
     { }
 
-    ~FtlConnection()
-    {
-        // If we haven't already stopped, this should handle it.
-        Stop();
-    }
-
     /* Static methods */
     /**
      * @brief Attempts to parse an Orchestration Protocol Message Header out of the given bytes
@@ -258,8 +252,8 @@ public:
                 std::placeholders::_1));
         transport->SetOnConnectionClosed(std::bind(&FtlConnection::onTransportConnectionClosed, this));
 
-        // Start the transport
-        transport->Start();
+        // Start the transport thread
+        transport->StartAsync();
     }
 
     void Stop() override
@@ -492,7 +486,7 @@ private:
     void onTransportBytesReceived(const std::vector<std::byte>& bytes)
     {
         // Add received bytes to our buffer
-        spdlog::info("{} received {} bytes ...", GetHostname(), bytes.size());
+        spdlog::debug("{} received {} bytes ...", GetHostname(), bytes.size());
         transportReadBuffer.insert(transportReadBuffer.end(), bytes.begin(), bytes.end());
 
         while (true)

--- a/inc/FtlOrchestrationClient.h
+++ b/inc/FtlOrchestrationClient.h
@@ -30,9 +30,10 @@ class FtlOrchestrationClient
 {
 public:
     static std::shared_ptr<FtlConnection> Connect(
-        std::string hostname,
+        std::string targetHostname,
         std::vector<std::byte> preSharedKey,
-        uint16_t port = DEFAULT_PORT)
+        std::string myHostname = std::string(),
+        uint16_t targetPort = DEFAULT_PORT)
     {
         // Load SSL stuff
         SSL_load_error_strings();
@@ -45,8 +46,11 @@ public:
         addrHints.ai_socktype = SOCK_STREAM;
         addrHints.ai_protocol = IPPROTO_TCP;
         addrinfo* addrLookup = nullptr;
-        int lookupErr = 
-            getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &addrHints, &addrLookup);
+        int lookupErr = getaddrinfo(
+            targetHostname.c_str(),
+            std::to_string(targetPort).c_str(),
+            &addrHints,
+            &addrLookup);
         if (lookupErr != 0)
         {
             throw std::invalid_argument("Error looking up hostname");
@@ -72,7 +76,8 @@ public:
                 preSharedKey);
 
         // Create an FtlConnection on top of this transport
-        std::shared_ptr<FtlConnection> ftlConnection = std::make_shared<FtlConnection>(transport);
+        std::shared_ptr<FtlConnection> ftlConnection = 
+            std::make_shared<FtlConnection>(transport, myHostname);
         return ftlConnection;
     }
 

--- a/inc/FtlOrchestrationClient.h
+++ b/inc/FtlOrchestrationClient.h
@@ -65,7 +65,6 @@ public:
         {
             throw std::runtime_error("Could not connect to Orchestration service on given host");
         }
-        printf("%d CONNECT\n", socketHandle);
 
         // Fire up a TlsConnectionTransport to handle TLS on this socket
         std::shared_ptr<TlsConnectionTransport> transport = 
@@ -74,6 +73,9 @@ public:
                 socketHandle,
                 *(reinterpret_cast<sockaddr_in*>(targetAddr.ai_addr)),
                 preSharedKey);
+
+        // We're done with this by now
+        freeaddrinfo(addrLookup);
 
         // Create an FtlConnection on top of this transport
         std::shared_ptr<FtlConnection> ftlConnection = 

--- a/inc/FtlOrchestrationClient.h
+++ b/inc/FtlOrchestrationClient.h
@@ -61,6 +61,7 @@ public:
         {
             throw std::runtime_error("Could not connect to Orchestration service on given host");
         }
+        printf("%d CONNECT\n", socketHandle);
 
         // Fire up a TlsConnectionTransport to handle TLS on this socket
         std::shared_ptr<TlsConnectionTransport> transport = 

--- a/inc/IConnection.h
+++ b/inc/IConnection.h
@@ -215,4 +215,9 @@ public:
      * @brief Retrieve the hostname of the FTL server represented by this connection
      */
     virtual std::string GetHostname() = 0;
+
+    /**
+     * @brief Set the hostname of the FTL node represented by this connection
+     */
+    virtual void SetHostname(std::string hostname) = 0;
 };

--- a/inc/IConnection.h
+++ b/inc/IConnection.h
@@ -32,6 +32,17 @@ struct ConnectionIntroPayload
     uint8_t RelayLayer;
     std::string RegionCode;
     std::string Hostname;
+
+    bool operator==(const ConnectionIntroPayload& c)
+    {
+        return (
+            (VersionMajor == c.VersionMajor) &&
+            (VersionMinor == c.VersionMinor) &&
+            (VersionRevision == c.VersionRevision) &&
+            (RelayLayer == c.RelayLayer) &&
+            (RegionCode == c.RegionCode) && 
+            (Hostname == c.Hostname));
+    }
 };
 
 struct ConnectionOutroPayload

--- a/inc/IConnection.h
+++ b/inc/IConnection.h
@@ -111,7 +111,7 @@ public:
     virtual ~IConnection() = default;
 
     /**
-     * @brief Starts the connection in a new thread
+     * @brief Starts the connection
      */
     virtual void Start() = 0;
 

--- a/inc/IConnectionTransport.h
+++ b/inc/IConnectionTransport.h
@@ -32,20 +32,21 @@ public:
     virtual void Stop() = 0;
 
     /**
-     * @brief Read bytes from the transport
-     * @return std::vector<uint8_t> bytes read
-     */
-    virtual std::vector<uint8_t> Read() = 0;
-
-    /**
      * @brief Write bytes to the transport
      * @param bytes bytes to be written
      */
-    virtual void Write(const std::vector<uint8_t>& bytes) = 0;
+    virtual void Write(const std::vector<std::byte>& bytes) = 0;
 
     /**
      * @brief Sets the callback that will fire when this connection has been closed.
      * @param onConnectionClosed callback to fire on connection close
      */
     virtual void SetOnConnectionClosed(std::function<void(void)> onConnectionClosed) = 0;
+
+    /**
+     * @brief Set the callback that will fire when this connection has received bytes
+     * @param onBytesReceived callback to fire when bytes received
+     */
+    virtual void SetOnBytesReceived(
+        std::function<void(const std::vector<std::byte>&)> onBytesReceived) = 0;
 };

--- a/inc/IConnectionTransport.h
+++ b/inc/IConnectionTransport.h
@@ -22,9 +22,9 @@ public:
     virtual ~IConnectionTransport() = default;
 
     /**
-     * @brief Starts the connection
+     * @brief Starts the connection transport in a new thread
      */
-    virtual void Start() = 0;
+    virtual void StartAsync() = 0;
 
     /**
      * @brief Shuts down connection

--- a/inc/TlsConnectionTransport.h
+++ b/inc/TlsConnectionTransport.h
@@ -135,6 +135,7 @@ public:
             SSL_shutdown(ssl.get());
             shutdown(socketHandle, SHUT_RDWR);
             close(socketHandle);
+            printf("%d CLOSED: Triggered by local\n", socketHandle);
         }
     }
 
@@ -255,6 +256,7 @@ private:
             isStopping = true;
             shutdown(socketHandle, SHUT_RDWR);
             close(socketHandle);
+            printf("%d CLOSED: Triggered by remote\n", socketHandle);
         }
 
         // Avoid firing the closed callback twice

--- a/src/Orchestrator.cpp
+++ b/src/Orchestrator.cpp
@@ -137,9 +137,12 @@ void Orchestrator<TConnection>::newConnection(std::shared_ptr<TConnection> conne
             std::placeholders::_1));
 
     // Track the connection until we receive the opening intro message
-    std::lock_guard<std::mutex> lock(connectionsMutex);
-    spdlog::info("New connection, awaiting intro...");
-    pendingConnections.insert(connection);
+    {
+        std::lock_guard<std::mutex> lock(connectionsMutex);
+        spdlog::info("New connection, awaiting intro...");
+        pendingConnections.insert(connection);
+    }
+    connection->Start();
 }
 
 #pragma region Connection callback handlers
@@ -177,6 +180,8 @@ ConnectionResult Orchestrator<TConnection>::connectionIntro(
 {
     if (auto strongConnection = connection.lock())
     {
+        // Set the hostname
+        strongConnection->SetHostname(payload.Hostname);
         spdlog::info("FROM {}: Intro from {} v{}.{}.{}, Layer {}, Region {}",
             strongConnection->GetHostname(),
             payload.Hostname,

--- a/src/StreamStore.h
+++ b/src/StreamStore.h
@@ -131,6 +131,16 @@ public:
         return std::nullopt;
     }
 
+    /**
+     * @brief Clears all records
+     */
+    void Clear()
+    {
+        std::lock_guard<std::mutex> lock(streamStoreMutex);
+        streamByChannelId.clear();
+        streamsByIngestConnection.clear();
+    }
+
 private:
     std::mutex streamStoreMutex;
     std::map<ftl_channel_id_t, Stream<TConnection>> streamByChannelId;

--- a/src/SubscriptionStore.h
+++ b/src/SubscriptionStore.h
@@ -217,6 +217,16 @@ public:
         }
     }
 
+    /**
+     * @brief Clears all records
+     */
+    void Clear()
+    {
+        std::lock_guard<std::mutex> lock(subscriptionsStoreMutex);
+        subscriptionsByConnection.clear();
+        subscriptionsByChannel.clear();
+    }
+
 private:
     std::mutex subscriptionsStoreMutex;
     std::map<std::shared_ptr<TConnection>, std::set<std::shared_ptr<ChannelSubscription<TConnection>>>>

--- a/src/TlsConnectionManager.cpp
+++ b/src/TlsConnectionManager.cpp
@@ -75,7 +75,7 @@ void TlsConnectionManager<T>::Listen(std::promise<void>&& readyPromise)
         throw std::runtime_error(errStr.str());
     }
 
-    printf("%d BIND\n", listenSocketHandle); // REMOVE
+    spdlog::debug("TlsConnectionManager: Bound on fd {}", listenSocketHandle);
 
     // Listen on socket
     if (listen(listenSocketHandle, SOCKET_LISTEN_QUEUE_LIMIT) < 0)
@@ -88,7 +88,7 @@ void TlsConnectionManager<T>::Listen(std::promise<void>&& readyPromise)
     }
 
     // Accept new connections
-    spdlog::info("Listening on port {}...", listenPort);
+    spdlog::info("TlsConnectionManager: Listening on port {}...", listenPort);
     readyPromise.set_value(); // Indicate to promise that we are now listening
     while (true)
     {
@@ -105,7 +105,7 @@ void TlsConnectionManager<T>::Listen(std::promise<void>&& readyPromise)
             if (error == EINVAL)
             {
                 // This means we've closed the listen handle
-                spdlog::info("TLS Connection Manager shutting down...");
+                spdlog::info("TlsConnectionManager: Shutting down...");
                 break;
             }
             std::stringstream errStr;
@@ -114,9 +114,7 @@ void TlsConnectionManager<T>::Listen(std::promise<void>&& readyPromise)
             throw std::runtime_error(errStr.str());
         }
 
-        spdlog::info("Accepted new connection...");
-
-        printf("%d ACCEPTED\n", clientHandle); // REMOVE
+        spdlog::info("TlsConnectionManager: Accepted new connection on fd {}", clientHandle);
 
         std::shared_ptr<TlsConnectionTransport> transport = 
             std::make_shared<TlsConnectionTransport>(
@@ -143,7 +141,7 @@ void TlsConnectionManager<T>::StopListening()
 {
     shutdown(listenSocketHandle, SHUT_RDWR);
     close(listenSocketHandle);
-    printf("%d CLOSED: Stop listener\n", listenSocketHandle); // REMOVE
+    spdlog::debug("TlsConnectionManager: Closed listening on fd {}", listenSocketHandle);
 }
 
 template <class T>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,16 +24,14 @@ int main()
     configuration->Load();
 
     // Set up our service to listen to orchestration connections via TCP/TLS
-    auto connectionManager = 
-        std::make_shared<TlsConnectionManager<FtlConnection>>(configuration->GetPreSharedKey());
-    std::unique_ptr<Orchestrator<FtlConnection>> orchestrator = 
-        std::make_unique<Orchestrator<FtlConnection>>(connectionManager);
+    auto orchestrator = std::make_unique<Orchestrator<FtlConnection>>(
+            std::make_unique<TlsConnectionManager<FtlConnection>>(
+                configuration->GetPreSharedKey()));
     
-    // Initialize our classes
-    connectionManager->Init();
+    // Initialize
     orchestrator->Init();
 
     // Off we go
-    connectionManager->Listen();
+    orchestrator->Run();
     return 0;
 }

--- a/test/TestLogging.h
+++ b/test/TestLogging.h
@@ -28,27 +28,29 @@ protected:
         case spdlog::level::debug:
         case spdlog::level::info:
         {
-            // BUG: Turns out that this makes Catch2 unhappy when called from
-            // multiple threads.
-            // possible workaround: disable this spdlog sink when in multi-threaded test cases?
-            //UNSCOPED_INFO(formattedMsg);
+            // BUG: Turns out calling UNSCOPED_INFO from multiple threads
+            // makes Catch2 unhappy.
+            // https://github.com/catchorg/Catch2/issues/1043
+            // UNSCOPED_INFO(formattedMsg);
             printf("%s", formattedMsg.c_str());
             break;
         }
         case spdlog::level::warn:
         {
-            // BUG: Turns out that this makes Catch2 unhappy when called from
-            // multiple threads.
-            //WARN(formattedMsg);
+            // BUG: Turns out calling WARN from multiple threads
+            // makes Catch2 unhappy.
+            // https://github.com/catchorg/Catch2/issues/1043
+            // WARN(formattedMsg);
             printf("%s", formattedMsg.c_str());
             break;
         }
         case spdlog::level::err:
         case spdlog::level::critical:
         {
-            // BUG: Turns out that this makes Catch2 unhappy when called from
-            // multiple threads.
-            //FAIL_CHECK(formattedMsg);
+            // BUG: Turns out calling FAIL_CHECK from multiple threads
+            // makes Catch2 unhappy.
+            // https://github.com/catchorg/Catch2/issues/1043
+            // FAIL_CHECK(formattedMsg);
             printf("%s", formattedMsg.c_str());
             break;
         }

--- a/test/TestLogging.h
+++ b/test/TestLogging.h
@@ -32,6 +32,7 @@ protected:
             // multiple threads.
             // possible workaround: disable this spdlog sink when in multi-threaded test cases?
             //UNSCOPED_INFO(formattedMsg);
+            printf("%s", formattedMsg.c_str());
             break;
         }
         case spdlog::level::warn:
@@ -39,6 +40,7 @@ protected:
             // BUG: Turns out that this makes Catch2 unhappy when called from
             // multiple threads.
             //WARN(formattedMsg);
+            printf("%s", formattedMsg.c_str());
             break;
         }
         case spdlog::level::err:
@@ -47,6 +49,7 @@ protected:
             // BUG: Turns out that this makes Catch2 unhappy when called from
             // multiple threads.
             //FAIL_CHECK(formattedMsg);
+            printf("%s", formattedMsg.c_str());
             break;
         }
         default:

--- a/test/functional/FunctionalTests.cpp
+++ b/test/functional/FunctionalTests.cpp
@@ -33,82 +33,29 @@ public:
                 std::byte(0x04), std::byte(0x05), std::byte(0x06), std::byte(0x07), 
                 std::byte(0x08), std::byte(0x09), std::byte(0x0a), std::byte(0x0b), 
                 std::byte(0x0c), std::byte(0x0d), std::byte(0x0e), std::byte(0x0f), 
-            })
-    { }
+            }),
+        orchestrator(std::make_unique<Orchestrator<FtlConnection>>(
+            std::make_unique<TlsConnectionManager<FtlConnection>>(preSharedKey)))
+    {
+        orchestrator->Init();
+
+        // Start running on a separate thread,
+        // but wait until we're ready to accept new connections
+        std::promise<void> readyPromise;
+        std::future<void> readyFuture = readyPromise.get_future();
+        orchestratorThread = std::thread(
+            [this, &readyPromise]()
+            {
+                this->orchestrator->Run(std::move(readyPromise));
+            });
+        readyFuture.get();
+    }
 
     ~FunctionalTestsFixture()
     {
-        // Stop all incoming connections
-        for (const auto& connection : connections)
-        {
-            connection->Stop();
-        }
-        if (connectionManager)
-        {
-            connectionManager->StopListening();
-            connectionManagerListenThread.join();
-        }
-    }
-
-    /**
-     * @brief Instantiates a new ConnectionManager and sets up callbacks
-     */
-    void InitConnectionManager()
-    {
-        connectionManager = std::make_shared<TlsConnectionManager<FtlConnection>>(preSharedKey);
-        connectionManager->SetOnNewConnection(
-            std::bind(
-                &FunctionalTestsFixture::onNewConnectionManagerConnection,
-                this,
-                std::placeholders::_1));
-        connectionManager->Init();
-    }
-
-    /**
-     * @brief Instantiates a new Orchestrator and sets up callbacks
-     * 
-     */
-    void InitOrchestrator()
-    {
-        orchestrator = std::make_shared<Orchestrator<FtlConnection>>(connectionManager);
-        orchestrator->Init();
-    }
-
-    /**
-     * @brief Starts listening for connections on a separate thread
-     */
-    void StartConnectionManagerListening()
-    {
-        std::promise<void> listeningPromise;
-        std::future<void> listeningFuture = listeningPromise.get_future();
-        connectionManagerListenThread = std::thread(
-            [this, &listeningPromise]()
-            {
-                this->connectionManager->Listen(std::move(listeningPromise));
-            });
-        listeningFuture.get();
-    }
-
-    /**
-     * @brief Waits for a new connection to be reported by ConnectionManager, or times out
-     * @param timeout how long to wait before timing out
-     * @return std::optional<std::shared_ptr<FtlConnection>> the new connection
-     */
-    std::optional<std::shared_ptr<FtlConnection>> WaitForNewConnection(
-        std::chrono::milliseconds timeout = std::chrono::milliseconds(5000))
-    {
-        std::unique_lock<std::mutex> lock(connectionManagerMutex);
-        if (newConnections.size() <= 0)
-        {
-            connectionManagerConditionVariable.wait_for(lock, timeout);
-        }
-        if (newConnections.size() > 0)
-        {
-            auto returnValue = newConnections.front();
-            newConnections.pop_front();
-            return returnValue;
-        }
-        return std::nullopt;
+        // Stop listening
+        orchestrator->Stop();
+        orchestratorThread.join();
     }
 
     /**
@@ -139,207 +86,17 @@ public:
         return connection;
     }
 
-    /**
-     * @brief Starts a given client connection on a new thread
-     * @param client client connection to start
-     * @return std::future<void> future returning a value when the connection has started
-     */
-    std::future<void> StartClientAsync(std::shared_ptr<FtlConnection> client)
-    {
-        return std::async(std::launch::async, &FtlConnection::Start, client.get());
-    }
-
-    /**
-     * @brief
-     *  Creates a new FtlConnection client, connects it to the local orchestration service,
-     *  sends an Intro message with the given parameters, and returns both the local and received
-     *  connections.
-     *  NOTE: This function should only be used without an Orchestrator, as the Orchestrator will
-     *  override the connectionmanager event for new connections.
-     * @param clientHostname hostname for the new client
-     * @param clientRegionCode region code for the new client
-     * @return
-     *  std::pair<std::shared_ptr<FtlConnection>, std::shared_ptr<FtlConnection>> 
-     *  first reference is the client connection, second reference is the received connection.
-     */
-    std::pair<std::shared_ptr<FtlConnection>, std::shared_ptr<FtlConnection>>
-        ConnectAndListenForNewClientIntro(
-            std::string clientHostname,
-            std::string clientRegionCode = "global")
-    {
-        // Create the client connection, connect it, and get reference to the received connection
-        std::shared_ptr<FtlConnection> clientConnection = ConnectNewClient(clientHostname);
-        std::future<void> clientConnected = StartClientAsync(clientConnection);
-        auto tryRecvConnection = WaitForNewConnection();
-        REQUIRE(tryRecvConnection.has_value());
-        auto recvConnection = tryRecvConnection.value();
-
-        // When we receive an intro payload, store it away and notify our thread
-        std::optional<ConnectionIntroPayload> recvIntroPayload;
-        std::mutex introRecvMutex;
-        std::condition_variable introRecvCv;
-        recvConnection->SetOnIntro(
-            [&introRecvCv, &recvIntroPayload](ConnectionIntroPayload introPayload)
-            {
-                recvIntroPayload = introPayload;
-                introRecvCv.notify_all();
-                return ConnectionResult
-                {
-                    .IsSuccess = true
-                };
-            });
-
-        recvConnection->Start();
-        clientConnected.get();
-
-        // Send the intro and wait to receive it
-        clientConnection->SendIntro(
-            ConnectionIntroPayload
-            {
-                .VersionMajor = 0,
-                .VersionMinor = 0,
-                .VersionRevision = 1,
-                .RelayLayer = 0,
-                .RegionCode = clientRegionCode,
-                .Hostname = clientHostname,
-            });
-        std::unique_lock<std::mutex> lock(introRecvMutex);
-        introRecvCv.wait_for(lock, std::chrono::milliseconds(5000));
-
-        REQUIRE(recvIntroPayload.has_value());
-
-        return { clientConnection, recvConnection };
-    }
-
 protected:
-    std::vector<std::byte> preSharedKey;
-    std::mutex connectionManagerMutex;
-    std::condition_variable connectionManagerConditionVariable;
-    std::shared_ptr<TlsConnectionManager<FtlConnection>> connectionManager;
-    std::thread connectionManagerListenThread;
-    std::shared_ptr<Orchestrator<FtlConnection>> orchestrator;
-    std::list<std::shared_ptr<FtlConnection>> newConnections;
-    std::list<std::shared_ptr<FtlConnection>> connections;
-    std::list<std::shared_ptr<FtlConnection>> clients;
-
-    void onNewConnectionManagerConnection(std::shared_ptr<FtlConnection> connection)
-    {
-        {
-            std::lock_guard<std::mutex> lock(connectionManagerMutex);
-            connections.push_back(connection);
-            newConnections.push_back(connection);
-        }
-        connectionManagerConditionVariable.notify_all();
-    }
+    const std::vector<std::byte> preSharedKey;
+    const std::shared_ptr<Orchestrator<FtlConnection>> orchestrator;
+    std::thread orchestratorThread;
 };
-
-TEST_CASE_METHOD(
-    FunctionalTestsFixture,
-    "Orchestration client connect and disconnect",
-    "[functional]")
-{
-    InitConnectionManager();
-    StartConnectionManagerListening();
-    
-    // Now connect a client
-    std::shared_ptr<FtlConnection> clientConnection = ConnectNewClient("test");
-
-    // We need to start the client in a separate thread so we can accept the connection
-    // in this thread without deadlocking.
-    std::future<void> clientStarted = StartClientAsync(clientConnection);
-
-    // Make sure the server successfully received the connection
-    auto tryReceivedConnection = WaitForNewConnection();
-    REQUIRE(tryReceivedConnection.has_value());
-    auto receivedConnection = tryReceivedConnection.value();
-
-    // Record when we see the received connection disconnect
-    std::promise<void> receivedConnClosedPromise;
-    std::future<void> receivedConnClosedFuture = receivedConnClosedPromise.get_future();
-    receivedConnection->SetOnConnectionClosed(
-        [&receivedConnClosedPromise]()
-        {
-            receivedConnClosedPromise.set_value_at_thread_exit();
-        });
-
-    // Start the received connection
-    receivedConnection->Start();
-
-    // Make sure our client finished starting
-    clientStarted.get();
-
-    // Shut down the client
-    clientConnection->Stop();
-
-    // Wait for the received connection to close
-    receivedConnClosedFuture.get();
-}
-
-TEST_CASE_METHOD(
-    FunctionalTestsFixture,
-    "Intro messages sent by the client are received",
-    "[functional]")
-{
-    InitConnectionManager();
-    StartConnectionManagerListening();
-
-    std::shared_ptr<FtlConnection> clientConnection = ConnectNewClient("test");
-    std::future<void> clientConnected = StartClientAsync(clientConnection);
-    
-    auto tryReceivedConnection = WaitForNewConnection();
-    REQUIRE(tryReceivedConnection.has_value());
-    auto receivedConnection = tryReceivedConnection.value();
-
-    // When we receive an intro payload, store it away and notify our thread
-    std::optional<ConnectionIntroPayload> recvIntroPayload;
-    std::mutex introRecvMutex;
-    std::condition_variable introRecvCv;
-    receivedConnection->SetOnIntro(
-        [&introRecvCv, &recvIntroPayload](ConnectionIntroPayload introPayload) -> ConnectionResult
-        {
-            recvIntroPayload = introPayload;
-            introRecvCv.notify_all();
-            return ConnectionResult
-            {
-                .IsSuccess = true
-            };
-        });
-
-    // Start received connection and ensure client has started
-    receivedConnection->Start();
-    clientConnected.get();
-
-    // Send an intro from the client
-    ConnectionIntroPayload introPayload
-        {
-            // TODO: Store version info in some common header...
-            .VersionMajor = 0,
-            .VersionMinor = 0,
-            .VersionRevision = 1,
-            .RelayLayer = 0,
-            .RegionCode = "test",
-            .Hostname = "test-host",
-        };
-    clientConnection->SendIntro(introPayload);
-
-    // Wait to see if we got the intro...
-    std::unique_lock<std::mutex> lock(introRecvMutex);
-    introRecvCv.wait_for(lock, std::chrono::milliseconds(5000));
-
-    REQUIRE(recvIntroPayload.has_value());
-    bool payloadIsEqual = (recvIntroPayload.value() == introPayload);
-    REQUIRE(payloadIsEqual == true);
-}
 
 TEST_CASE_METHOD(
     FunctionalTestsFixture,
     "Ingest to Edge relaying",
     "[functional][relay]")
 {
-    InitConnectionManager();
-    InitOrchestrator();
-    StartConnectionManagerListening();
-
     ftl_channel_id_t channelId = 1234;
     ftl_stream_id_t streamId = 5678;
     std::vector<std::byte> streamKey
@@ -397,4 +154,7 @@ TEST_CASE_METHOD(
     REQUIRE(recvRelayPayload.value().StreamId == streamId);
     bool streamKeyMatch = (recvRelayPayload.value().StreamKey == streamKey);
     REQUIRE(streamKeyMatch == true);
+
+    ingestClient->Stop();
+    edgeClient->Stop();
 }

--- a/test/mocks/MockConnection.h
+++ b/test/mocks/MockConnection.h
@@ -242,6 +242,11 @@ public:
         return hostname;
     }
 
+    void SetHostname(std::string hostname) override
+    {
+        this->hostname = hostname;
+    }
+
 private:
     std::function<void(void)> onConnectionClosed;
     connection_cb_intro_t onIntro;

--- a/test/mocks/MockConnectionTransport.h
+++ b/test/mocks/MockConnectionTransport.h
@@ -48,7 +48,7 @@ public:
     }
 
     /* IConnectionTransport */
-    void Start() override
+    void StartAsync() override
     { }
 
     void Stop() override

--- a/test/unit/OrchestratorUnitTests.cpp
+++ b/test/unit/OrchestratorUnitTests.cpp
@@ -31,7 +31,6 @@ protected:
     static const uint8_t protocolVersionMajor = 0;
     static const uint8_t protocolVersionMinor = 0;
     static const uint8_t protocolVersionRevision = 0;
-    std::shared_ptr<MockConnectionManager<MockConnection>> connectionManager;
     std::unique_ptr<Orchestrator<MockConnection>> orchestrator;
 
     /**
@@ -39,9 +38,8 @@ protected:
      */
     void init()
     {
-        connectionManager = std::make_shared<MockConnectionManager<MockConnection>>();
-        connectionManager->Init();
-        orchestrator = std::make_unique<Orchestrator<MockConnection>>(connectionManager);
+        orchestrator = std::make_unique<Orchestrator<MockConnection>>(
+            std::make_unique<MockConnectionManager<MockConnection>>());
         orchestrator->Init();
     }
 
@@ -84,6 +82,9 @@ protected:
         const std::shared_ptr<MockConnection>& connection,
         bool fireIntro = true)
     {
+        const auto& connectionManager = 
+            reinterpret_cast<const std::unique_ptr<MockConnectionManager<MockConnection>>&>(
+                orchestrator->GetConnectionManager());
         connectionManager->MockFireNewConnection(connection);
         if (fireIntro)
         {


### PR DESCRIPTION
This change introduces the first truly end-to-end functional test that connects an `ingest` node and an `edge` node, subscribes the `edge` node to a channel, publishes a stream from the `ingest` node, and confirms that `orchestrator` sends a relay message to the `ingest` node indicating it should relay the stream to the `edge`.

Many threading problems, race conditions, and annoying little bugs were revealed by this test and fixed.

Additional functional tests should follow to further prove out the orchestrator, then integration of the `FtlOrchestrationClient` into the Janus FTL plugin.