### PR TITLE
❌ Test disconnect destroys subs and relays

### DIFF
--- a/inc/FtlConnection.h
+++ b/inc/FtlConnection.h
@@ -388,7 +388,7 @@ public:
     {
         std::vector<std::byte> messagePayload
         {
-            static_cast<uint8_t>(payload.IsStartRelay),
+            static_cast<std::byte>(payload.IsStartRelay),
         };
         messagePayload.reserve(11 + payload.TargetHostname.size() + payload.StreamKey.size());
         auto channelIdBytes = ConvertToNetworkPayload(payload.ChannelId);

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,17 @@
-project('janus-ftl-orchestrator', 'cpp')
+project(
+    'janus-ftl-orchestrator',
+    'cpp',
+    default_options: [
+        'cpp_std=c++2a',
+        'cpp_args=-Wno-unknown-pragmas',
+        'werror=true',
+    ]
+)
+
+# Set the DEBUG define if we're a debug build
+if get_option('buildtype').startswith('debug')
+    add_project_arguments('-DDEBUG', language : 'cpp')
+endif
 
 sources = files([
     'src/Configuration.cpp',
@@ -14,7 +27,6 @@ deps = [
     subproject('spdlog').get_variable('spdlog_dep'), # use wrapped copy of spdlog
 ]
 
-cppargs = ['-std=c++20', '-Wno-unknown-pragmas']
 incdir = include_directories(['src', 'inc'])
 
 executable(
@@ -22,9 +34,8 @@ executable(
     sources,
     include_directories: incdir,
     dependencies: deps,
-    cpp_args: cppargs,
     install: true,
-    install_dir: '/usr/local/bin'
+    install_dir: '/usr/local/bin',
 )
 
 testsources = files([
@@ -45,5 +56,4 @@ executable(
     testsources,
     include_directories: incdir,
     dependencies: deps,
-    cpp_args: cppargs
 )

--- a/test/functional/FunctionalTests.cpp
+++ b/test/functional/FunctionalTests.cpp
@@ -87,6 +87,7 @@ public:
     }
 
 protected:
+    const int WAIT_TIMEOUT_MS = 1000;
     const std::vector<std::byte> preSharedKey;
     const std::shared_ptr<Orchestrator<FtlConnection>> orchestrator;
     std::thread orchestratorThread;
@@ -121,7 +122,7 @@ TEST_CASE_METHOD(
         [&recvRelayPayload, &recvRelayCv](ConnectionRelayPayload relayPayload)
         {
             recvRelayPayload = relayPayload;
-            recvRelayCv.notify_all();
+            recvRelayCv.notify_one();
             return ConnectionResult
             {
                 .IsSuccess = true
@@ -148,13 +149,121 @@ TEST_CASE_METHOD(
 
     // Check to see if we've received the relay message
     std::unique_lock<std::mutex> lock(recvRelayMutex);
-    recvRelayCv.wait_for(lock, std::chrono::milliseconds(5000));
+    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
     REQUIRE(recvRelayPayload.has_value());
+    REQUIRE(recvRelayPayload.value().IsStartRelay == true);
     REQUIRE(recvRelayPayload.value().ChannelId == channelId);
     REQUIRE(recvRelayPayload.value().StreamId == streamId);
+    REQUIRE(recvRelayPayload.value().TargetHostname == edgeClient->GetHostname());
     bool streamKeyMatch = (recvRelayPayload.value().StreamKey == streamKey);
     REQUIRE(streamKeyMatch == true);
+    lock.unlock();
 
+    // Clear the value and un-subscribe the stream
+    recvRelayPayload.reset();
+    edgeClient->SendChannelSubscription(
+        ConnectionSubscriptionPayload
+        {
+            .IsSubscribe = false,
+            .ChannelId = channelId,
+            .StreamKey = std::vector<std::byte>(),
+        });
+    
+    // Check to make sure we've received the stop relay message
+    lock.lock();
+    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    REQUIRE(recvRelayPayload.has_value());
+    REQUIRE(recvRelayPayload.value().IsStartRelay == false);
+    REQUIRE(recvRelayPayload.value().ChannelId == channelId);
+    REQUIRE(recvRelayPayload.value().StreamId == streamId);
+    REQUIRE(recvRelayPayload.value().TargetHostname == edgeClient->GetHostname());
+    lock.unlock();
+
+    // Stop connections
     ingestClient->Stop();
     edgeClient->Stop();
+}
+
+TEST_CASE_METHOD(
+    FunctionalTestsFixture,
+    "Relays stopped when target disconnects",
+    "[functional][relay]")
+{
+    ftl_channel_id_t channelId = 1234;
+    ftl_stream_id_t streamId = 5678;
+    std::vector<std::byte> streamKey
+    {
+        std::byte(0x0f), std::byte(0x0e), std::byte(0x0d), std::byte(0x0c),
+        std::byte(0x0b), std::byte(0x0a), std::byte(0x09), std::byte(0x08), 
+        std::byte(0x07), std::byte(0x06), std::byte(0x05), std::byte(0x04), 
+        std::byte(0x03), std::byte(0x02), std::byte(0x01), std::byte(0x00), 
+    };
+
+    // Connect an ingest node
+    auto ingestClient = ConnectNewClient("ingest", true);
+
+    // Connect an edge node
+    auto edgeClient = ConnectNewClient("edge", true);
+    
+    // Track when the ingest receives a relay message
+    std::optional<ConnectionRelayPayload> recvRelayPayload;
+    std::mutex recvRelayMutex;
+    std::condition_variable recvRelayCv;
+    ingestClient->SetOnStreamRelay(
+        [&recvRelayPayload, &recvRelayCv](ConnectionRelayPayload relayPayload)
+        {
+            recvRelayPayload = relayPayload;
+            recvRelayCv.notify_one();
+            return ConnectionResult
+            {
+                .IsSuccess = true
+            };
+        });
+
+    // Subscribe the edge node to the channel
+    edgeClient->SendChannelSubscription(
+        ConnectionSubscriptionPayload
+        {
+            .IsSubscribe = true,
+            .ChannelId = channelId,
+            .StreamKey = streamKey,
+        });
+
+    // Publish the stream from the ingest
+    ingestClient->SendStreamPublish(
+        ConnectionPublishPayload
+        {
+            .IsPublish = true,
+            .ChannelId = channelId,
+            .StreamId = streamId,
+        });
+
+    // Check to see if we've received the relay message
+    std::unique_lock<std::mutex> lock(recvRelayMutex);
+    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    REQUIRE(recvRelayPayload.has_value());
+    REQUIRE(recvRelayPayload.value().IsStartRelay == true);
+    REQUIRE(recvRelayPayload.value().ChannelId == channelId);
+    REQUIRE(recvRelayPayload.value().StreamId == streamId);
+    REQUIRE(recvRelayPayload.value().TargetHostname == edgeClient->GetHostname());
+    bool streamKeyMatch = (recvRelayPayload.value().StreamKey == streamKey);
+    REQUIRE(streamKeyMatch == true);
+    lock.unlock();
+
+    // Clear the value and stop the edge node
+    recvRelayPayload.reset();
+    edgeClient->Stop();
+    
+    // Check to make sure we've received the stop relay message
+    lock.lock();
+    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    REQUIRE(recvRelayPayload.has_value());
+    REQUIRE(recvRelayPayload.value().IsStartRelay == false);
+    REQUIRE(recvRelayPayload.value().ChannelId == channelId);
+    REQUIRE(recvRelayPayload.value().StreamId == streamId);
+    REQUIRE(recvRelayPayload.value().TargetHostname == edgeClient->GetHostname());
+    lock.unlock();
+
+    // Stop connections
+    ingestClient->Stop();
 }

--- a/test/functional/FunctionalTests.cpp
+++ b/test/functional/FunctionalTests.cpp
@@ -87,7 +87,7 @@ public:
     }
 
 protected:
-    const int WAIT_TIMEOUT_MS = 1000;
+    const std::chrono::milliseconds WAIT_TIMEOUT = std::chrono::milliseconds(1000);
     const std::vector<std::byte> preSharedKey;
     const std::shared_ptr<Orchestrator<FtlConnection>> orchestrator;
     std::thread orchestratorThread;
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(
 
     // Check to see if we've received the relay message
     std::unique_lock<std::mutex> lock(recvRelayMutex);
-    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    recvRelayCv.wait_for(lock, WAIT_TIMEOUT);
     REQUIRE(recvRelayPayload.has_value());
     REQUIRE(recvRelayPayload.value().IsStartRelay == true);
     REQUIRE(recvRelayPayload.value().ChannelId == channelId);
@@ -171,7 +171,7 @@ TEST_CASE_METHOD(
     
     // Check to make sure we've received the stop relay message
     lock.lock();
-    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    recvRelayCv.wait_for(lock, WAIT_TIMEOUT);
     REQUIRE(recvRelayPayload.has_value());
     REQUIRE(recvRelayPayload.value().IsStartRelay == false);
     REQUIRE(recvRelayPayload.value().ChannelId == channelId);
@@ -240,7 +240,7 @@ TEST_CASE_METHOD(
 
     // Check to see if we've received the relay message
     std::unique_lock<std::mutex> lock(recvRelayMutex);
-    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    recvRelayCv.wait_for(lock, WAIT_TIMEOUT);
     REQUIRE(recvRelayPayload.has_value());
     REQUIRE(recvRelayPayload.value().IsStartRelay == true);
     REQUIRE(recvRelayPayload.value().ChannelId == channelId);
@@ -256,7 +256,7 @@ TEST_CASE_METHOD(
     
     // Check to make sure we've received the stop relay message
     lock.lock();
-    recvRelayCv.wait_for(lock, std::chrono::milliseconds(WAIT_TIMEOUT_MS));
+    recvRelayCv.wait_for(lock, WAIT_TIMEOUT);
     REQUIRE(recvRelayPayload.has_value());
     REQUIRE(recvRelayPayload.value().IsStartRelay == false);
     REQUIRE(recvRelayPayload.value().ChannelId == channelId);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -20,6 +20,9 @@ int main(int argc, char* argv[])
     auto testLoggingSink = std::make_shared<TestSink<std::mutex>>();
     auto testLogger = std::make_shared<spdlog::logger>("testlogger", testLoggingSink);
     spdlog::set_default_logger(testLogger);
+#ifdef DEBUG
+    spdlog::set_level(spdlog::level::trace);
+#endif
 
     // Test!
     int result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
Added a test to ensure that when clients are disconnected, their subscriptions are removed, and associated relays are stopped.

Also updated the meson build to move default options to the right place, and `#define DEBUG` when running a debug build so we get debug level logging.