### PR TITLE
🐛 Fix occasional hang on new connection

### DIFF
--- a/inc/TlsConnectionTransport.h
+++ b/inc/TlsConnectionTransport.h
@@ -278,7 +278,7 @@ private:
             }
             
             // Try again
-            connectResult = SSL_connect(ssl.get());
+            connectResult = isServer ? SSL_accept(ssl.get()) : SSL_connect(ssl.get());
         }
 
         spdlog::debug("{} SSL CONNECTED", socketHandle);


### PR DESCRIPTION
This fixes an oversight with how new TLS connections are accepted by the server.

If the socket doesn't immediately return all of the information OpenSSL needs to complete the connection, the server will end up calling `SSL_connect` instead of `SSL_accept`, causing an infinite loop as the connection will never complete, blocking the thread that accepts new connections.

This change fixes the issue by calling `SSL_accept` on the server as appropriate.